### PR TITLE
Korean language debug translation

### DIFF
--- a/Unshaky/ko.lproj/Debug.strings
+++ b/Unshaky/ko.lproj/Debug.strings
@@ -1,6 +1,6 @@
 
 /* Class = "NSButtonCell"; title = "Clear"; ObjectID = "0R5-gZ-Fp4"; */
-"0R5-gZ-Fp4.title" = "Clear";
+"0R5-gZ-Fp4.title" = "정리";
 
 /* Class = "NSButtonCell"; title = "Copy"; ObjectID = "GtH-xA-uyU"; */
-"GtH-xA-uyU.title" = "Copy";
+"GtH-xA-uyU.title" = "복사";


### PR DESCRIPTION
Korean Language debug strings translation
+ in this build(0.4.8), missing Localizable.strings in ko.lproj, this reason, some menu shown english.