### PR TITLE
fix image stretching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <img src="README/logo.web.png" alt="Unshaky" height="40"> Unshaky
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=JLLGBFQKTTX9W&source=url) [![Github All Releases](https://img.shields.io/github/downloads/aahung/Unshaky/total.svg)](https://github.com/aahung/Unshaky/releases) [![Build Status](https://travis-ci.org/aahung/Unshaky.svg?branch=master)](https://travis-ci.org/aahung/Unshaky)
 
-<img src="README/menubar.png" alt="Menubar" height="250">
+<img src="README/menubar.png" alt="Menubar" width="331">
 
 **Unshaky** tries to address an issue on the butterfly keyboard (Macbook, Macbook Air 2018 & MacBook Pro 2016 and later): Double Key Press (See "[User complaints](#complaints-about-this-issue)" below). 
 


### PR DESCRIPTION
this change corrects image stretching on small-screen mobile devices.
before fix
<img width="342" alt="cap 2" src="https://user-images.githubusercontent.com/36481442/68267248-d3e4be80-0062-11ea-8dbc-b8e357079cef.png">
